### PR TITLE
team name triggers

### DIFF
--- a/triggers/national.yaml
+++ b/triggers/national.yaml
@@ -1,2 +1,7 @@
-match: "(nati|rati|natxia|eternati)onal"
+match: "(nati|internat|rati|natxia|xia|eternati)onal|morgana|morganya|sukokomon|sukoko"
 interaction: triggers/national
+channels:
+  whitelist:
+    - 766904461880066069
+    - 782175023250276377
+    - 866903104522944562


### PR DESCRIPTION
couldn't find these channels in constants so i hope the ids work:
#questions-pls-halp
#new-character-help (currently #yae-miko-help)
#abyss-help

not sure if any other channels need it, the regulars in tc-gen already use k!team a lot when purples come in and when teams names are actually used it's usually a meme