### PR TITLE
update k!reens and add admin to points command whitelist

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -57,7 +57,7 @@ modules:
   pointsSystem:
     enabled: true
     permissions:
-      whitelist: ${ [ ROLES.VERIFIED ] }
+      whitelist: ${ [ ...getValuesRecursive(ROLES.ADMIN), ROLES.VERIFIED ] }
         
     loggingChannel: "${ CHANNELS.BOT_LOGGING }"
     

--- a/interactions/miscellaneous/copypastas/reens.yaml
+++ b/interactions/miscellaneous/copypastas/reens.yaml
@@ -1,2 +1,2 @@
 content: |-
-  "Omg, is that? Childe and Ayato simp, almost Xiao Mains owner, TCL carrier, resident insomniac, GitHub master, and Bike Pedal lover, Reens? No, it couldn't be"
+  "Omg, is that? Childe and Ayato simp, almost Xiao Mains owner, TCL carrier, resident insomniac, GitHub master, COVID magnet, and Bike Pedal lover, Reens? No, it couldn't be"


### PR DESCRIPTION
reens is now a covid magnet and add admin role to points command whitelist